### PR TITLE
Make memory_store responsible for its own concurrency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 default: test lint
 
 test:
-	@go test ./... -cover -v
+	@go test ./... -cover -v -race
 
 lint:
 	@$(shell go list -f {{.Target}} golang.org/x/lint/golint) ./...
@@ -11,9 +11,9 @@ lint:
 serve:
 	@go run cmd/scale/main.go
 
-race:
+serve.race:
 	@go run -race cmd/scale/main.go
-	
+
 codegen:
 	@protoc -I internal/pkg/rpc internal/pkg/rpc/proto/scale.proto --go_out=plugins=grpc:internal/pkg/rpc
 

--- a/internal/pkg/node/node.go
+++ b/internal/pkg/node/node.go
@@ -201,25 +201,16 @@ func (node *Node) bootstrap(n *RemoteNode) {
 
 // GetLocal return a value stored on this node
 func (node *Node) GetLocal(key scale.Key) ([]byte, error) {
-	node.RLock()
-	defer node.RUnlock()
-
 	return node.store.Get(key), nil
 }
 
 // SetLocal set a value in the local store
 func (node *Node) SetLocal(key scale.Key, value []byte) error {
-	node.RLock()
-	defer node.RUnlock()
-
 	return node.store.Set(key, value)
 }
 
 // Get return a value stored on this node
 func (node *Node) Get(key scale.Key) ([]byte, error) {
-	node.RLock()
-	defer node.RUnlock()
-
 	succ, err := node.FindSuccessor(key)
 	remoteNode := NewRemoteNode(succ.GetAddr(), node)
 
@@ -237,9 +228,6 @@ func (node *Node) Get(key scale.Key) ([]byte, error) {
 
 // Set set a value in the local store
 func (node *Node) Set(key scale.Key, value []byte) error {
-	node.RLock()
-	defer node.RUnlock()
-
 	succ, err := node.FindSuccessor(key)
 	remoteNode := NewRemoteNode(succ.GetAddr(), node)
 

--- a/internal/pkg/node/node_test.go
+++ b/internal/pkg/node/node_test.go
@@ -1,0 +1,78 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/msmedes/scale/internal/pkg/keyspace"
+)
+
+const Addr = "0.0.0.0:3000"
+
+func TestNewNode(t *testing.T) {
+	n := NewNode(Addr)
+
+	t.Run("sets successor to itself", func(t *testing.T) {
+		s, err := n.GetSuccessor()
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !keyspace.Equal(s.GetID(), n.GetID()) {
+			t.Errorf("expected successor to be itself, got: %x", n.GetID())
+		}
+	})
+
+	t.Run("sets predecessor to itself", func(t *testing.T) {
+		p, err := n.GetPredecessor()
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !keyspace.Equal(p.GetID(), n.GetID()) {
+			t.Errorf("expected predecessor to be itself, got: %x", n.GetID())
+		}
+	})
+
+	t.Run("sets finger table to itself", func(t *testing.T) {
+		ids := n.GetFingerTableIDs()
+
+		for i, id := range ids {
+			if !keyspace.Equal(id, n.GetID()) {
+				t.Errorf("invalid finger table entry at index %d: %x", i, id)
+			}
+		}
+	})
+}
+
+func TestCheckPredecessor(t *testing.T) {
+	n := NewNode(Addr)
+
+	t.Run("does nothing when predecessor is itself", func(t *testing.T) {
+		n.checkPredecessor()
+		p, err := n.GetPredecessor()
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !keyspace.Equal(p.GetID(), n.GetID()) {
+			t.Errorf("expected predessor check to not have changed p. got: %x", p.GetID())
+		}
+	})
+
+	t.Run("removes predecessor if there is an error pinging it", func(t *testing.T) {
+		n.predecessor = NewRemoteNode("0.0.0.0:3001", n)
+		n.checkPredecessor()
+		p, err := n.GetPredecessor()
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if p != nil {
+			t.Errorf("expected to have removed predecessor")
+		}
+	})
+}

--- a/internal/pkg/store/memory_store.go
+++ b/internal/pkg/store/memory_store.go
@@ -1,6 +1,10 @@
 package store
 
-import "github.com/msmedes/scale/internal/pkg/scale"
+import (
+	"sync"
+
+	"github.com/msmedes/scale/internal/pkg/scale"
+)
 
 type data = map[scale.Key][]byte
 
@@ -8,7 +12,8 @@ type data = map[scale.Key][]byte
 type MemoryStore struct {
 	scale.Store
 
-	data data
+	mutex sync.RWMutex
+	data  data
 }
 
 // NewMemoryStore set up a new store
@@ -20,23 +25,31 @@ func NewMemoryStore() *MemoryStore {
 
 // Get get the given key
 func (s *MemoryStore) Get(key scale.Key) []byte {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	return s.data[key]
 }
 
 // Set set the given key
 func (s *MemoryStore) Set(key scale.Key, value []byte) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	s.data[key] = value
 	return nil
 }
 
 // Del delete the given key
 func (s *MemoryStore) Del(key scale.Key) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	delete(s.data, key)
 	return nil
 }
 
 // Keys list of keys
 func (s *MemoryStore) Keys() []scale.Key {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	keys := make([]scale.Key, 0, len(s.data))
 
 	for k := range s.data {

--- a/internal/pkg/store/memory_store_test.go
+++ b/internal/pkg/store/memory_store_test.go
@@ -1,0 +1,62 @@
+package store
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/msmedes/scale/internal/pkg/keyspace"
+)
+
+func TestMemoryStore(t *testing.T) {
+	store := NewMemoryStore()
+	key1 := keyspace.StringToKey("hello")
+	val1 := []byte("world")
+
+	store.Set(key1, val1)
+	got := store.Get(key1)
+
+	if !bytes.Equal(got, val1) {
+		t.Errorf("expected %x got %x", val1, got)
+	}
+
+	keys := store.Keys()
+
+	if !keyspace.Equal(keys[0], key1) {
+		t.Errorf("expected keys[0] to be %x got %x", key1, keys[0])
+	}
+
+	store.Del(key1)
+	got = store.Get(key1)
+
+	if !bytes.Equal(got, nil) {
+		t.Errorf("expected %x got %x", val1, got)
+	}
+}
+
+func TestMemoryStoreThreadSafety(t *testing.T) {
+	store := NewMemoryStore()
+	key := keyspace.StringToKey("key")
+
+	var w sync.WaitGroup
+	w.Add(3)
+
+	for i := 0; i < 3; i++ {
+		go func(j int) {
+			defer w.Done()
+			time.Sleep(time.Duration(j) * 10 * time.Millisecond)
+			str := fmt.Sprintf("val-%d", j)
+			store.Set(key, []byte(str))
+		}(i)
+	}
+
+	w.Wait()
+
+	got := string(store.Get(key))
+
+	if got != "val-2" {
+		t.Errorf("expected val-2 got %s", got)
+	}
+}

--- a/internal/pkg/store/memory_store_test.go
+++ b/internal/pkg/store/memory_store_test.go
@@ -15,25 +15,31 @@ func TestMemoryStore(t *testing.T) {
 	key1 := keyspace.StringToKey("hello")
 	val1 := []byte("world")
 
-	store.Set(key1, val1)
-	got := store.Get(key1)
+	t.Run("set and get", func(t *testing.T) {
+		store.Set(key1, val1)
+		got := store.Get(key1)
 
-	if !bytes.Equal(got, val1) {
-		t.Errorf("expected %x got %x", val1, got)
-	}
+		if !bytes.Equal(got, val1) {
+			t.Errorf("expected %x got %x", val1, got)
+		}
+	})
 
-	keys := store.Keys()
+	t.Run("keys", func(t *testing.T) {
+		keys := store.Keys()
 
-	if !keyspace.Equal(keys[0], key1) {
-		t.Errorf("expected keys[0] to be %x got %x", key1, keys[0])
-	}
+		if !keyspace.Equal(keys[0], key1) {
+			t.Errorf("expected keys[0] to be %x got %x", key1, keys[0])
+		}
+	})
 
-	store.Del(key1)
-	got = store.Get(key1)
+	t.Run("del", func(t *testing.T) {
+		store.Del(key1)
+		got := store.Get(key1)
 
-	if !bytes.Equal(got, nil) {
-		t.Errorf("expected %x got %x", val1, got)
-	}
+		if !bytes.Equal(got, nil) {
+			t.Errorf("expected %x got %x", val1, got)
+		}
+	})
 }
 
 func TestMemoryStoreThreadSafety(t *testing.T) {


### PR DESCRIPTION
- gonna start trying to hone in on the actual race conditions that are happening/possible and write tests to assert against them
- switch `RLock` to `Lock` for ops that mutate data
- make `mutex` a private prop rather than exposing the interface on the exported object
- in this specific case, let store handle its own mutex for the in memory map. if this gets swapped out with a diff underlying store(s), those will all have their own serialization/isolation guarantees and prob be optimized themselves
- add some basic node tests